### PR TITLE
change STOCK_ICON labels to freedesktop names

### DIFF
--- a/tomate/ui/dialogs/preference.py
+++ b/tomate/ui/dialogs/preference.py
@@ -140,7 +140,7 @@ class ExtensionTab:
         plugin_list_container = Gtk.ScrolledWindow(shadow_type=Gtk.ShadowType.IN)
         plugin_list_container.add(self.plugin_list)
 
-        self.settings_button = Gtk.Button.new_from_icon_name(Gtk.STOCK_PREFERENCES, Gtk.IconSize.MENU)
+        self.settings_button = Gtk.Button.new_from_icon_name("preferences-system", Gtk.IconSize.MENU)
         self.settings_button.set_properties(name="plugin.settings", sensitive=False)
         self.settings_button.connect("clicked", self._on_plugin_settings_clicked)
 

--- a/tomate/ui/widgets/headerbar.py
+++ b/tomate/ui/widgets/headerbar.py
@@ -58,14 +58,14 @@ class HeaderBar(Subscriber):
         self.widget = self._create_headerbar()
 
         self._start_button = self._add_button(
-            Gtk.STOCK_MEDIA_PLAY,
+            "media-playback-start",
             "Starts the session",
             HeaderBar.START_SHORTCUT,
             lambda *_: session.start(),
         )
 
         self._stop_button = self._add_button(
-            Gtk.STOCK_MEDIA_STOP,
+            "media-playback-stop",
             "Stops the session",
             HeaderBar.STOP_SHORTCUT,
             lambda *_: session.stop(),
@@ -74,7 +74,7 @@ class HeaderBar(Subscriber):
         )
 
         self._reset_button = self._add_button(
-            Gtk.STOCK_CLEAR,
+            "edit-clear",
             "Clear session count",
             HeaderBar.RESET_SHORTCUT,
             lambda *_: session.reset(),
@@ -106,7 +106,7 @@ class HeaderBar(Subscriber):
         return button
 
     def _add_preference_button(self, menu, shortcuts) -> None:
-        icon = Gtk.Image.new_from_icon_name(Gtk.STOCK_PREFERENCES, Gtk.IconSize.BUTTON)
+        icon = Gtk.Image.new_from_icon_name("preferences-system", Gtk.IconSize.BUTTON)
         button = Gtk.MenuButton(
             name=Menu.PREFERENCE_SHORTCUT.name,
             popup=menu.widget,


### PR DESCRIPTION
Gtk.STOCK_* are deprecated since Gtk 3.10 (news to me too...)

This is finally biting: On a stock Pop OS 21.10 system there is no gtk-media-play icon installed in Pop, Adwaita, or Hicolor themes. Effect is Session Start and Session Stop icons are broken.

This takes the approach recommended in Gtk docs to get icon by name. I've had a 10 minute googling session on if Gtk expose the freedesktop names as constants but it doesn't look like it, so static strings it is.