### PR TITLE
Don't add trailing .0 when gathering the RELEASE on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you use an Ubuntu-based distro, such as Mint, manually set the **RELEASE** va
 
 ### Debian 10+
 
-    RELEASE=`sed -n 's/VERSION_ID="\(.*\)"/\1\.0/p' /etc/os-release`
+    RELEASE=`sed -n 's/VERSION_ID="\(.*\)"/\1/p' /etc/os-release`
     sudo wget -O- http://download.opensuse.org/repositories/home:/eliostvs:/tomate/Debian_$RELEASE/Release.key | sudo apt-key add -
     sudo bash -c "echo 'deb http://download.opensuse.org/repositories/home:/eliostvs:/tomate/Debian_$RELEASE/ ./' > /etc/apt/sources.list.d/tomate.list"
     sudo apt-get update && sudo apt-get install tomate-gtk


### PR DESCRIPTION
The published debs are not in folders like Debian_11.0 but instead in folder like Debian_11. So there is no need to add a trailing .0 when computing the value of RELEASE